### PR TITLE
Fix message filter callback types

### DIFF
--- a/src/vo/node_vo.cpp
+++ b/src/vo/node_vo.cpp
@@ -264,9 +264,9 @@ public:
         cout << "start the thread" << endl;
     }
 
-    void tof_callback(const sensor_msgs::msg::PointCloud2::SharedPtr pcPtr,
-                      const sensor_msgs::msg::Image::SharedPtr mono8Ptr,
-                      const sensor_msgs::msg::Image::SharedPtr depthPtr)
+    void tof_callback(const sensor_msgs::msg::PointCloud2::ConstSharedPtr pcPtr,
+                      const sensor_msgs::msg::Image::ConstSharedPtr mono8Ptr,
+                      const sensor_msgs::msg::Image::ConstSharedPtr depthPtr)
     {
         //tic_toc_ros tt_cb;
         FrameCount++;


### PR DESCRIPTION
## Summary
- fix callback signature in `node_vo.cpp` to accept ConstSharedPtr arguments

## Testing
- `cmake ..` *(fails: could not find ament_cmake)*

------
https://chatgpt.com/codex/tasks/task_e_6850028c337c832b879fdef5156d0d2c