### PR TITLE
Use rviz2 for RViz launch

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ cd ..
 colcon build
 source install/setup.bash
 ```
-After sourcing the workspace you can launch RViz with:
+After sourcing the workspace you can launch RViz2 with:
 ```
 ros2 launch tof_vio rviz.launch.py
 ```

--- a/launch/rviz.launch.py
+++ b/launch/rviz.launch.py
@@ -8,9 +8,9 @@ def generate_launch_description():
     pkg_share = get_package_share_directory('tof_vio')
     return LaunchDescription([
         Node(
-            package='rviz',
-            executable='rviz',
-            name='rviz',
+            package='rviz2',
+            executable='rviz2',
+            name='rviz2',
             arguments=['-d', os.path.join(pkg_share, 'config', 'vio.rviz')]
         )
     ])


### PR DESCRIPTION
## Summary
- call rviz2 rather than rviz in launch file
- mention RViz2 in README

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_685021511ec8832b9ab3e75ab2ac53ab