### PR TITLE
Fix Nodelet dependency for ROS2

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,11 @@ After sourcing the workspace you can launch RViz2 with:
 ```
 ros2 launch tof_vio rviz.launch.py
 ```
+On ROS2 the ICP node runs as a regular executable rather than a nodelet. If you
+see errors about the `nodelet` package missing, run the ICP node directly with:
+```
+ros2 run tof_vio icp_node
+```
 ### Verify using Dataset
 Using our recorded rosbag:
 

--- a/launch/platform.launch.py
+++ b/launch/platform.launch.py
@@ -45,11 +45,10 @@ def generate_launch_description():
     }
 
     icp_node = Node(
-        package='nodelet',
-        executable='nodelet',
-        name='ICP_Node',
+        package='tof_vio',
+        executable='icp_node',
+        name='icp_node',
         output='screen',
-        arguments=['standalone', 'nodelet_ns/NICP'],
         remappings=[
             ('/input_gt', '/gt'),
             ('/input_imu', '/imu'),

--- a/launch/vio.launch.py
+++ b/launch/vio.launch.py
@@ -30,11 +30,10 @@ def generate_launch_description():
     }
 
     icp_node = Node(
-        package='nodelet',
-        executable='nodelet',
-        name='ICP_Node',
+        package='tof_vio',
+        executable='icp_node',
+        name='icp_node',
         output='screen',
-        arguments=['standalone', 'nodelet_ns/NICP'],
         remappings=[
             ('/input_gt', '/gt'),
             ('/input_imu', '/imu'),

--- a/launch/vio_platform/t265.launch.py
+++ b/launch/vio_platform/t265.launch.py
@@ -34,9 +34,9 @@ def generate_launch_description():
     ]
 
     realsense_include = IncludeLaunchDescription(
-        AnyLaunchDescriptionSource(
+        PythonLaunchDescriptionSource(
             os.path.join(get_package_share_directory('realsense2_camera'),
-                         'launch/includes/nodelet.launch.xml')
+                         'launch', 'rs_launch.py')
         ),
         launch_arguments={
             'tf_prefix': LaunchConfiguration('tf_prefix'),


### PR DESCRIPTION
## Summary
- remove `nodelet` from ROS2 launch files
- mention direct ICP node invocation in README
- load Realsense driver using ROS2 launch file

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`
- `colcon test --packages-select tof_vio` *(fails: colcon not found)*

------
https://chatgpt.com/codex/tasks/task_e_68503ef5a190832b9b51224f27bbac69