### PR TITLE
Update export build type

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -47,6 +47,8 @@
   <exec_depend>message_filters</exec_depend>
 
   <!-- The export tag contains other, unspecified, tags -->
-  <export/>
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
 
 </package>


### PR DESCRIPTION
## Summary
- add `ament_cmake` build_type to export section of package.xml

## Testing
- `colcon test --event-handlers console_direct+ --packages-select tof_vio` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685045733238832b93883ec08ddcbdbb